### PR TITLE
fix: Use styled props in Collapse component

### DIFF
--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -12,7 +12,7 @@ interface RenderComponentProps {
   opacity: number
 }
 
-const RenderComponent = styled.div<RenderComponentProps>`
+const CollapseContainer = styled.div<RenderComponentProps>`
   height: ${({ height }) => height};
   transform-origin: top;
   opacity: ${({ opacity }) => opacity};
@@ -54,12 +54,12 @@ export const Collapse: React.FC<CollapseProps> = (props) => {
   }, [shown, contentHeight])
 
   return (
-    <RenderComponent
+    <CollapseContainer
       as={as}
       height={renderHeight}
       opacity={prevShown || shown ? 1 : 0}
     >
       {mountChild ? <div ref={contentsRef}>{children}</div> : null}
-    </RenderComponent>
+    </CollapseContainer>
   )
 }

--- a/src/components/Collapse.tsx
+++ b/src/components/Collapse.tsx
@@ -1,4 +1,5 @@
 import React, { ReactHTML, useLayoutEffect, useRef, useState } from 'react'
+import styled from 'styled-components'
 
 export interface CollapseProps {
   shown: boolean
@@ -6,8 +7,22 @@ export interface CollapseProps {
   as?: keyof ReactHTML
 }
 
+interface RenderComponentProps {
+  height: number | 'auto'
+  opacity: number
+}
+
+const RenderComponent = styled.div<RenderComponentProps>`
+  height: ${({ height }) => height};
+  transform-origin: top;
+  opacity: ${({ opacity }) => opacity};
+  transition: height 0.3s ease, opacity 0.3s ease;
+  pointer-events: ${({ opacity }) => (opacity ? 'all' : 'none')};
+  overflow: 'hidden';
+`
+
 export const Collapse: React.FC<CollapseProps> = (props) => {
-  const { as = 'div', shown, children } = props
+  const { as, shown, children } = props
 
   const contentsRef = useRef<HTMLDivElement>(null)
   const [contentHeight, setContentHeight] = useState<number>(0)
@@ -38,17 +53,11 @@ export const Collapse: React.FC<CollapseProps> = (props) => {
     }
   }, [shown, contentHeight])
 
-  const RenderComponent = as
   return (
     <RenderComponent
-      style={{
-        height: renderHeight,
-        transformOrigin: 'top',
-        opacity: prevShown || shown ? 1 : 0,
-        transition: `height .3s ease, opacity .3s ease`,
-        pointerEvents: prevShown || shown ? 'all' : 'none',
-        overflow: 'hidden',
-      }}
+      as={as}
+      height={renderHeight}
+      opacity={prevShown || shown ? 1 : 0}
     >
       {mountChild ? <div ref={contentsRef}>{children}</div> : null}
     </RenderComponent>


### PR DESCRIPTION
리액트에서 권장하는 "진리의 원천"(Single source of truth) 개념을 바탕으로 꼭 필요하고 최소한의 props 의 조합으로 새 속성 값을 할당하는 방법을 사용했습니다:

> _어떤 값이 props 또는 state로부터 계산될 수 있다면, 아마도 그 값을 state에 두어서는 안 됩니다._
>
> [교훈, State 끌어올리기 – React](https://ko.reactjs.org/docs/lifting-state-up.html#lessons-learned)

로컬에서 스토리북을 실행해서 컴포넌트가 이상 없는지 확인을 마쳤습니다..!