### PR TITLE
fix: invalid return type of cssVariables function

### DIFF
--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -2,7 +2,7 @@ import { css } from 'styled-components'
 import { SolvedTheme } from '../styles'
 
 export type MakeKebabCase<S extends string, ReturnQueue extends string = ''> =
-  // Separate string into first character T and rest string U, only works if length > 1
+  // Separate string into first character T and rest string U, only works if length >= 1
   S extends `${infer T}${infer U}`
   // If it's the first character of whole string, just lowercase first character
   ? ReturnQueue extends ''
@@ -12,7 +12,7 @@ export type MakeKebabCase<S extends string, ReturnQueue extends string = ''> =
   ? MakeKebabCase<U, `${ReturnQueue}-${Lowercase<T>}`>
   // or, just append itself
   : MakeKebabCase<U, `${ReturnQueue}${T}`>
-  // It's else branch of the first length > 1 check
+  // It's else branch of the first length >= 1 check
   : `${ReturnQueue}${S}`
 
 export const toCssName = <S extends string>(name: S): MakeKebabCase<S> =>

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -38,14 +38,14 @@ export const cssVariables = <
 
   const vars = Object.fromEntries(
     names.map((name) => [
-      name ,
-      `--solvedac-${toCssName(prefix)}-${toCssName(name)}` ,
-    ] )
+      name,
+      `--solvedac-${toCssName(prefix)}-${toCssName(name)}`,
+    ])
   ) as { [K in keyof T]: VariableName<P, K> }
 
   const v = Object.fromEntries(
     Object.entries(vars).map(([k, v]) => [k, `var(${v})`])
-  )  as { [K in keyof T]: `var(${VariableName<P, K>})` }
+  ) as { [K in keyof T]: `var(${VariableName<P, K>})` }
 
   const styles = (theme: SolvedTheme): string =>
     (

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -1,8 +1,25 @@
 import { css } from 'styled-components'
 import { SolvedTheme } from '../styles'
 
-export const toCssName = (name: string): string =>
-  name.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`).replace(/^-/, '')
+export type MakeKebabCase<S extends string, ReturnQueue extends string = ''> =
+  // Separate string into first character T and rest string U, only works if length > 1
+  S extends `${infer T}${infer U}`
+  // If it's the first character of whole string, just lowercase first character
+  ? ReturnQueue extends ''
+  ? MakeKebabCase<U, Lowercase<T>>
+  // if it's uppercased character, append -${Lowercase<T>} into return queue
+  : T extends Uppercase<T>
+  ? MakeKebabCase<U, `${ReturnQueue}-${Lowercase<T>}`>
+  // or, just append itself
+  : MakeKebabCase<U, `${ReturnQueue}${T}`>
+  // It's else branch of the first length > 1 check
+  : `${ReturnQueue}${S}`
+
+export const toCssName = <S extends string>(name: S): MakeKebabCase<S> =>
+  name.replace(/[A-Z]/g, (m) => `-${m.toLowerCase()}`).replace(/^-/, '') as MakeKebabCase<S>
+
+export type VariableName<Prefix extends string, Name> =
+  `--solvedac-${MakeKebabCase<Prefix>}-${MakeKebabCase<Name extends string ? Name : string>}`
 
 export const cssVariables = <
   T extends {
@@ -13,22 +30,22 @@ export const cssVariables = <
   defaults: T,
   prefix: P
 ): {
-  vars: { [key in keyof T]: `--solvedac-${string}` }
-  v: { [key in keyof T]: `var(--solvedac-${P}-${string})` }
+  vars: { [K in keyof T]: VariableName<P, K> }
+  v: { [K in keyof T]: `var(${VariableName<P, K>})` }
   styles: (theme: SolvedTheme) => string
 } => {
-  const names = Object.keys(defaults)
+  const names = Object.keys(defaults) 
 
   const vars = Object.fromEntries(
     names.map((name) => [
-      name,
-      `--solvedac-${toCssName(prefix)}-${toCssName(name)}`,
-    ])
-  ) as { [key in keyof T]: `--solvedac-${string}` }
+      name ,
+      `--solvedac-${toCssName(prefix)}-${toCssName(name)}` ,
+    ] )
+  ) as { [K in keyof T]: VariableName<P, K> }
 
   const v = Object.fromEntries(
     Object.entries(vars).map(([k, v]) => [k, `var(${v})`])
-  ) as { [key in keyof T]: `var(--solvedac-${P}-${string})` }
+  )  as { [K in keyof T]: `var(${VariableName<P, K>})` }
 
   const styles = (theme: SolvedTheme): string =>
     (

--- a/src/utils/styles.ts
+++ b/src/utils/styles.ts
@@ -34,7 +34,7 @@ export const cssVariables = <
   v: { [K in keyof T]: `var(${VariableName<P, K>})` }
   styles: (theme: SolvedTheme) => string
 } => {
-  const names = Object.keys(defaults) 
+  const names = Object.keys(defaults)
 
   const vars = Object.fromEntries(
     names.map((name) => [


### PR DESCRIPTION
closes #4 

기존 타이핑에서 실제 값과 타입이 다른 문제를 해결합니다.
복잡한 타입이 활용됨에 따라 컴파일 시간이나 에디터 반응 속도에 악영향을 미칠 수 있으므로 단순화된 <code>&#96;--solvedac-${string}&#96;</code>도 고려해보았으나, 기존 코드의 목적이 타입 정확성에 가까운 것으로 보여 기존 목적에 부합하게 고쳤습니다.